### PR TITLE
feat: Add comprehensive README for Network Science assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# 📚 Network Science Assignments - IIITD (CSE655, Winter 2025) 🕸️
+
+Welcome to the repository for the Network Science (CSE655) course assignments from Indraprastha Institute of Information Technology Delhi (IIITD). This was a 6xx level undergraduate course offered in Winter 2025.
+
+**Note:** All assignments were completed in groups of three.
+
+This repository contains all assignments for the Network Science course. Each assignment folder includes the question PDF, Python notebooks with the solutions, datasets used, and images generated.
+
+---
+
+## 🔬 Assignment 1: Network Fundamentals & Analysis
+
+This assignment focused on understanding basic network properties and analyzing various datasets. We explored concepts like degree distributions, path lengths, clustering coefficients, and different network visualization techniques.
+
+**Key Topics & Analyses:**
+*   Calculation and visualization of degree, path length, and clustering coefficient distributions.
+*   Analysis of in-degree and out-degree for directed networks.
+*   Comparison of network properties for datasets like Facebook social networks, gene interaction networks, and Wikipedia vote networks.
+*   Application of different graph layout algorithms (circular, y-organic, default).
+*   Exploration of the Gilbert random graph model.
+
+**Key Files:**
+*   **Questions:** [`Assignment-1/Assignment_01_CSE655_Network Science_Winter2025.pdf`](Assignment-1/Assignment_01_CSE655_Network%20Science_Winter2025.pdf)
+*   **Codes:** [`Assignment-1/Codes/`](Assignment-1/Codes/) (Jupyter Notebooks: `Question1.ipynb` - `Question5.ipynb`)
+*   **Datasets:** Located in [`Assignment-1/Dataset/`](Assignment-1/Dataset/) (e.g., `facebook_combined.txt`, `genes_network.csv`, `wikipedia_vote_network.csv`)
+*   **Output Images:** Visualizations can be found in [`Assignment-1/Images/`](Assignment-1/Images/) and [`Assignment-1/Question5-Images&PDF/`](Assignment-1/Question5-Images&PDF/)
+
+---
+
+## 📊 Assignment 2: Network Models & Community Structures
+
+This assignment delved into generative models for networks and further analysis of network characteristics, including community structures within real-world datasets like the yeast interactome.
+
+**Key Topics & Analyses:**
+*   Implementation and analysis of the Watts-Strogatz model for small-world networks.
+*   Degree distribution analysis, including log-log plots for identifying scale-free properties.
+*   Clustering coefficient distributions.
+*   Analysis and visualization of the yeast protein interaction network.
+
+**Key Files:**
+*   **Questions:** [`Assignment-2/Assignment_02_CSE655_Network Science_Winter2025.pdf`](Assignment-2/Assignment_02_CSE655_Network%20Science_Winter2025.pdf)
+*   **Codes:** Notebooks are organized by question in `Assignment-2/Q1/` through `Assignment-2/Q5/` (e.g., `q1.ipynb`, `q2.ipynb`)
+*   **Datasets:** Located in `Assignment-2/Q4/` and `Assignment-2/Q5/` (e.g., `facebook_combined.txt`, `yeast_interactome_dataset.txt`, `numerical_yeast_data.csv`)
+*   **Output Images:** Visualizations can be found within respective question folders (e.g., `Assignment-2/Q1/q1_watts_model.png`, `Assignment-2/Q5/yeast_interactome.png`)
+
+---
+
+## 🔗 Assignment 3: Network Robustness & Advanced Models
+
+The third assignment explored network robustness, shuffling techniques, and advanced network models, comparing their properties against real-world networks.
+
+**Key Topics & Analyses:**
+*   Implementation and comparison of the configuration model.
+*   Analysis of network properties after edge swapping (degree-preserving randomization).
+*   Investigation of assortativity (k-Nearest Neighbors, knn) in original vs. randomized networks.
+*   Application to datasets like a Facebook-like social network and an email network.
+
+**Key Files:**
+*   **Questions:** [`Assignment-3/Assignment_03_CSE655_Network Science_Winter2025.pdf`](Assignment-3/Assignment_03_CSE655_Network%20Science_Winter2025.pdf)
+*   **Codes:** [`Assignment-3/Codes/`](Assignment-3/Codes/) (Jupyter Notebooks: `q1.ipynb`, `q2.ipynb`, `q3.ipynb`)
+*   **Datasets:** Located in [`Assignment-3/Dataset/`](Assignment-3/Dataset/) (e.g., `Facebook-like Social Network.txt`, `email-Eu-core.txt`)
+*   **Output Images:** Visualizations can be found in [`Assignment-3/Images/`](Assignment-3/Images/) (e.g., `configuration_model_vs_original.png`, `knn_vs_k_swapping.png`)
+
+---
+
+Feel free to explore the notebooks and datasets to understand the analyses performed! 🚀


### PR DESCRIPTION
This commit introduces a new README.md file for the repository.

The README includes:
- Course details: Network Science (CSE655), IIITD, Winter 2025, 6xx undergraduate course.
- A note that assignments were group projects.
- Structured sections for each of the three assignments, detailing:
    - Key topics and analyses performed.
    - Links to question PDFs.
    - Links to code directories (Jupyter notebooks).
    - Information about datasets used.
    - Pointers to output images and visualizations.
- Emojis to enhance readability and engagement.

This README replaces the previously empty one and provides a good overview of the repository's contents.